### PR TITLE
Update orjson to ^3.11.1 for Python 3.14 support

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 Sphinx==8.1.3
 sphinx-rtd-theme==3.0.2
-orjson==3.10.13
+orjson>=3.11.1
 -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-orjson = "^3.10.13"
+orjson = "^3.11.1"
 tqdm = "^4.67.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Updates orjson dependency from ^3.10.13 to ^3.11.1 to support Python 3.14.

## Changes
- `pyproject.toml`: Update orjson from ^3.10.13 to ^3.11.1
- `docs/requirements.txt`: Update orjson from ==3.10.13 to >=3.11.1

Same fix as in lean-lsp-mcp: https://github.com/oOo0oOo/lean-lsp-mcp/pull/31

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)