### PR TITLE
Enable widget support in LSP initialization

### DIFF
--- a/leanclient/base_client.py
+++ b/leanclient/base_client.py
@@ -93,7 +93,8 @@ class BaseLeanLSPClient:
                 "processId": os.getpid(),
                 "rootUri": self._local_to_uri(self.project_path),
                 "initializationOptions": {
-                    "editDelay": 1  # It seems like this has no effect.
+                    "editDelay": 1,
+                    "hasWidgets": True,
                 },
             },
         )


### PR DESCRIPTION
Add `hasWidgets: True` to initializationOptions.

This enables interactive diagnostics to include widget data (e.g., base64 images from `#png`).

Ref: https://github.com/oOo0oOo/lean-lsp-mcp/pull/73#issuecomment-2518665285