### PR TITLE
Add simple CI workflow for linting and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync --extra dev
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --extra test
+      - run: uv run pytest -m unit


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs on PRs and pushes to main.

- **Lint job**: ruff check and format verification
- **Test job**: pytest unit tests across Python 3.10-3.13

This is a simpler alternative to #19 - it only runs unit tests (no Lean installation required), which avoids the complexity of setting up elan/mathlib in CI.

Closes #25