### PR TITLE
[fix] Add is_ready() check to range mode initial completion

### DIFF
--- a/leanclient/file_manager.py
+++ b/leanclient/file_manager.py
@@ -684,7 +684,11 @@ class LSPFileManager(BaseLeanLSPClient):
         with self._opened_files_lock:
             state = self.opened_files[path]
             if use_range:
-                is_complete = state.is_line_range_complete(start_line, end_line)
+                # Check both range completion and readiness to handle Lean 4.22 timing
+                # where processing: [] can arrive before actual diagnostics
+                is_complete = state.is_line_range_complete(
+                    start_line, end_line
+                ) and state.is_ready()
             else:
                 is_complete = state.complete
             uri = state.uri

--- a/tests/integration/test_line_range_diagnostics.py
+++ b/tests/integration/test_line_range_diagnostics.py
@@ -164,6 +164,38 @@ def test_filter_diagnostics_by_range_uses_fullrange():
     assert messages == {"truncated_range", "normal_range"}
 
 
+def test_range_complete_but_not_ready():
+    """Range complete but is_ready() False should prevent early return (Lean 4.22 timing fix).
+
+    In Lean 4.22+, processing: [] can arrive before actual diagnostics.
+    This tests that is_line_range_complete() alone is not sufficient -
+    we also need is_ready() to be True before considering the range complete.
+    """
+    import time
+
+    # State simulating Lean 4.22 timing: processing done, but no diagnostics yet
+    state = FileState(
+        uri="file:///test.lean",
+        content="test",
+        current_processing=[],  # Processing done
+        diagnostics_version=0,  # Has received a version
+        diagnostics=[],  # But no diagnostics yet
+        processing=False,  # Not processing
+        wait_for_diag_done=False,  # RPC not confirmed
+    )
+    # Set last_activity to now so grace period hasn't elapsed
+    state.last_activity = time.monotonic()
+
+    # is_line_range_complete() alone returns True
+    assert state.is_line_range_complete(10, 20)
+
+    # But is_ready() returns False (no diagnostics, RPC not done, within grace period)
+    assert not state.is_ready()
+
+    # Combined check (what get_diagnostics should use) returns False
+    assert not (state.is_line_range_complete(10, 20) and state.is_ready())
+
+
 # ============================================================================
 # Integration-style tests with mocked file manager
 # ============================================================================


### PR DESCRIPTION
Range mode in `get_diagnostics()` could skip waiting entirely when `is_line_range_complete()` returned True, missing the Lean 4.22 timing protection where `processing: []` arrives before actual diagnostics.

The fix adds `and state.is_ready()` to the initial completion check at line 687, matching what's already done inside `_wait_for_line_range()`.

Fixes #29