### PR TITLE
fix: normalize windows paths and read utf8

### DIFF
--- a/leanclient/base_client.py
+++ b/leanclient/base_client.py
@@ -177,6 +177,11 @@ class BaseLeanLSPClient:
                     pass
 
     # URI HANDLING
+    @staticmethod
+    def _normalize_local_path(local_path: str | os.PathLike[str]) -> str:
+        """Normalize Lean project-local paths to forward slashes."""
+        return urllib.parse.unquote(str(local_path)).replace("\\", "/")
+
     def _local_to_uri(self, local_path: str | os.PathLike[str]) -> str:
         """Convert a local file path to a URI.
 
@@ -192,7 +197,9 @@ class BaseLeanLSPClient:
         Returns:
             str: URI representation of the file.
         """
-        path = (self.project_path / Path(local_path)).resolve()
+        path = (
+            self.project_path / Path(self._normalize_local_path(local_path))
+        ).resolve()
         return urllib.parse.unquote(path.as_uri())
 
     def _locals_to_uris(self, local_paths: list[str]) -> list[str]:
@@ -217,8 +224,8 @@ class BaseLeanLSPClient:
         try:
             rel_path = abs_path.relative_to(self.project_path)
         except ValueError:
-            return str(abs_path)
-        return str(rel_path)
+            return abs_path.as_posix()
+        return rel_path.as_posix()
 
     # LANGUAGE SERVER RPC INTERACTION
     def clear_history(self):

--- a/leanclient/client.py
+++ b/leanclient/client.py
@@ -445,6 +445,8 @@ class LeanLSPClient(LSPFileManager, BaseLeanLSPClient):
         Returns:
             list: Document symbols.
         """
+        path = self._normalize_local_path(path)
+
         with self._opened_files_lock:
             if path not in self.opened_files:
                 needs_open = True
@@ -572,6 +574,8 @@ class LeanLSPClient(LSPFileManager, BaseLeanLSPClient):
         Returns:
             list: Folding ranges.
         """
+        path = self._normalize_local_path(path)
+
         with self._opened_files_lock:
             if path not in self.opened_files:
                 needs_open = True
@@ -1209,6 +1213,8 @@ class LeanLSPClient(LSPFileManager, BaseLeanLSPClient):
         Returns:
             dict | None: Module info or None.
         """
+        path = self._normalize_local_path(path)
+
         # Ensure file is opened and processed so imports are available
         self.get_diagnostics(path)
 

--- a/leanclient/file_manager.py
+++ b/leanclient/file_manager.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 import time
-import urllib.parse
 from dataclasses import dataclass, field
 from typing import Any, Iterator
 
@@ -318,7 +317,7 @@ class LSPFileManager(BaseLeanLSPClient):
         """
         uris = self._locals_to_uris(paths)
         for path, uri in zip(paths, uris):
-            with open(self._uri_to_abs(uri), "r") as f:
+            with open(self._uri_to_abs(uri), "r", encoding="utf-8") as f:
                 txt = normalize_newlines(f.read())
 
             # Initialize file state
@@ -351,6 +350,8 @@ class LSPFileManager(BaseLeanLSPClient):
         Returns:
             dict: Response or error.
         """
+        path = self._normalize_local_path(path)
+
         with self._opened_files_lock:
             if path not in self.opened_files:
                 needs_open = True
@@ -452,7 +453,7 @@ class LSPFileManager(BaseLeanLSPClient):
                 f"Warning! Can not open more than {self.max_opened_files} files at once. Increase LeanLSPClient.max_opened_files or open less files."
             )
 
-        paths = [urllib.parse.unquote(p) for p in paths]
+        paths = [self._normalize_local_path(p) for p in paths]
 
         # Separate files into categories
         with self._opened_files_lock:
@@ -469,7 +470,7 @@ class LSPFileManager(BaseLeanLSPClient):
                 # Sync from disk using update
                 for path in already_open:
                     abs_path = self._uri_to_abs(self._local_to_uri(path))
-                    with open(abs_path, "r") as f:
+                    with open(abs_path, "r", encoding="utf-8") as f:
                         new_content = normalize_newlines(f.read())
 
                     with self._opened_files_lock:
@@ -534,6 +535,8 @@ class LSPFileManager(BaseLeanLSPClient):
             path (str): Relative file path to update.
             changes (list[DocumentContentChange]): List of changes to apply.
         """
+        path = self._normalize_local_path(path)
+
         with self._opened_files_lock:
             if path not in self.opened_files:
                 raise FileNotFoundError(
@@ -583,6 +586,7 @@ class LSPFileManager(BaseLeanLSPClient):
             path (str): Relative file path to update.
             content (str): New complete file content.
         """
+        path = self._normalize_local_path(path)
         content = normalize_newlines(content)
 
         with self._opened_files_lock:
@@ -608,6 +612,8 @@ class LSPFileManager(BaseLeanLSPClient):
             paths (list[str]): List of relative file paths to close.
             blocking (bool): Not blocking can be risky if you close files frequently or reopen them.
         """
+        paths = [self._normalize_local_path(path) for path in paths]
+
         # Only close if file is open
         with self._opened_files_lock:
             missing = [p for p in paths if p not in self.opened_files]
@@ -719,6 +725,7 @@ class LSPFileManager(BaseLeanLSPClient):
         if start_line is not None and end_line is not None:
             if start_line > end_line:
                 raise ValueError("start_line must be <= end_line")
+        path = self._normalize_local_path(path)
 
         # Use range mode if either start_line or end_line is provided (supports open-ended ranges)
         use_range = start_line is not None or end_line is not None
@@ -815,6 +822,8 @@ class LSPFileManager(BaseLeanLSPClient):
         Returns:
             str: Content of the file.
         """
+        path = self._normalize_local_path(path)
+
         with self._opened_files_lock:
             state = self.opened_files.get(path)
             if state is not None:

--- a/leanclient/single_file_client.py
+++ b/leanclient/single_file_client.py
@@ -17,6 +17,8 @@ class SingleFileClient:
     """
 
     def __init__(self, client: "leanclient.client.LeanLSPClient", file_path: str):
+        file_path = client._normalize_local_path(file_path)
+
         # Check if file exists
         path = (client.project_path / Path(file_path)).resolve()
         if not path.exists():

--- a/tests/unit/test_windows_paths.py
+++ b/tests/unit/test_windows_paths.py
@@ -1,0 +1,74 @@
+import builtins
+import threading
+from pathlib import Path
+
+import pytest
+
+from leanclient.base_client import BaseLeanLSPClient
+from leanclient.file_manager import LSPFileManager
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_normalize_local_path_uses_forward_slashes() -> None:
+    assert (
+        BaseLeanLSPClient._normalize_local_path(r"src\Unicode.lean")
+        == "src/Unicode.lean"
+    )
+
+
+def test_uri_to_local_uses_forward_slashes(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    target = project / "src" / "Unicode.lean"
+    target.parent.mkdir(parents=True)
+    target.write_text("theorem test : Nat := 1\n", encoding="utf-8")
+
+    client = object.__new__(BaseLeanLSPClient)
+    client.project_path = project.resolve()
+
+    assert client._uri_to_local(target.resolve().as_uri()) == "src/Unicode.lean"
+
+
+def test_open_new_files_reads_utf8(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    lean_file = tmp_path / "Unicode.lean"
+    lean_file.write_text("theorem test : ℕ → ℕ := id\n", encoding="utf-8")
+
+    recorded: dict[str, str | None] = {}
+
+    def recording_open(file, mode="r", *args, **kwargs):
+        recorded["encoding"] = kwargs.get("encoding")
+        return builtins.open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr("leanclient.file_manager.open", recording_open, raising=False)
+
+    manager = object.__new__(LSPFileManager)
+    manager.opened_files = {}
+    manager._opened_files_lock = threading.Lock()
+    manager._recently_closed = set()
+    manager._locals_to_uris = lambda _paths: [lean_file.resolve().as_uri()]
+    manager._uri_to_abs = lambda _uri: lean_file
+    manager._send_notification = lambda *_args, **_kwargs: None
+
+    manager._open_new_files(["src/Unicode.lean"])
+
+    assert recorded["encoding"] == "utf-8"
+    assert manager.opened_files["src/Unicode.lean"].content == (
+        "theorem test : ℕ → ℕ := id\n"
+    )
+
+
+def test_open_files_normalizes_paths() -> None:
+    manager = object.__new__(LSPFileManager)
+    manager.max_opened_files = 4
+    manager.opened_files = {}
+    manager._opened_files_lock = threading.Lock()
+
+    opened: list[str] = []
+    manager._open_new_files = lambda paths, _mode: opened.extend(paths)
+
+    manager.open_files([r"src\Unicode.lean"])
+
+    assert opened == ["src/Unicode.lean"]


### PR DESCRIPTION
- file_manager.py now reads Lean files with `encoding="utf-8"`.
- `BaseLeanLSPClient` normalizes project-local paths to forward slashes.
- `_uri_to_local` now returns forward-slash paths, including absolute fallback paths.
- Public file-manager paths are normalized before indexing opened_files, so callers can pass Windows-style paths without key mismatches.
- `SingleFileClient` normalizes its stored file path.
- Added unit coverage in tests/unit/test_windows_paths.py.