### PR TITLE
[fix] Handle path-type mathlib deps in needs_mathlib_cache_get

### DIFF
--- a/leanclient/utils.py
+++ b/leanclient/utils.py
@@ -257,6 +257,8 @@ def needs_mathlib_cache_get(project_path: Path) -> bool:
     # Resolve mathlib directory: path-type uses "dir" field, git-type uses .lake/packages/mathlib
     if mathlib_pkg.get("type") == "path":
         mathlib_dir = Path(mathlib_pkg["dir"])
+        if not mathlib_dir.is_absolute():
+            mathlib_dir = project_path / mathlib_dir
     else:
         mathlib_dir = project_path / ".lake/packages/mathlib"
 

--- a/leanclient/utils.py
+++ b/leanclient/utils.py
@@ -248,13 +248,20 @@ def needs_mathlib_cache_get(project_path: Path) -> bool:
 
     try:
         pkgs = orjson.loads(manifest.read_bytes()).get("packages", [])
-        if not any(p.get("name") == "mathlib" for p in pkgs):
+        mathlib_pkg = next((p for p in pkgs if p.get("name") == "mathlib"), None)
+        if mathlib_pkg is None:
             return False
     except Exception:
         return False
 
+    # Resolve mathlib directory: path-type uses "dir" field, git-type uses .lake/packages/mathlib
+    if mathlib_pkg.get("type") == "path":
+        mathlib_dir = Path(mathlib_pkg["dir"])
+    else:
+        mathlib_dir = project_path / ".lake/packages/mathlib"
+
     # Check if mathlib olean files already exist
-    olean_dir = project_path / ".lake/packages/mathlib/.lake/build/lib/lean/Mathlib"
+    olean_dir = mathlib_dir / ".lake/build/lib/lean/Mathlib"
     return not any(olean_dir.glob("*.olean"))
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -252,6 +252,23 @@ def test_needs_mathlib_cache_get_with_olean_files(tmp_path):
 
 
 @pytest.mark.unit
+def test_needs_mathlib_cache_get_with_relative_path_dep(tmp_path):
+    """Test path-type mathlib dependency with a relative dir."""
+    manifest_path = tmp_path / "lake-manifest.json"
+    manifest_path.write_text(
+        '{"packages": [{"name": "mathlib", "type": "path", "dir": "vendor/mathlib"}]}'
+    )
+
+    mathlib_build = (
+        tmp_path / "vendor" / "mathlib" / ".lake" / "build" / "lib" / "lean" / "Mathlib"
+    )
+    mathlib_build.mkdir(parents=True)
+    (mathlib_build / "Init.olean").write_text("")
+
+    assert needs_mathlib_cache_get(tmp_path) is False
+
+
+@pytest.mark.unit
 def test_needs_mathlib_cache_get_real_project(test_project_dir):
     """Test with real test project that has mathlib - should not need cache."""
     # The test project should already have mathlib cache available


### PR DESCRIPTION
Path-type dependencies in lake-manifest.json use a "dir" field instead of the default .lake/packages/mathlib location.

## Summary                                                                    
                                                                              
- Fix `needs_mathlib_cache_get` to correctly resolve mathlib directory when it's a **path-type** dependency in `lake-manifest.json`                       
- Previously the olean directory path was hardcoded to `.lake/packages/mathlib/...`, which breaks when mathlib is a local/path dependency
- Now inspects the `type` field: uses `dir` for path-type, falls back to `.lake/packages/mathlib` for git-type                                         
 
## Test plan                                                                  
                                                                
- [x] Verify with a project that has git-type mathlib (default case, passed in full test 3.10)          
- [x] Verify with a project that has path-type mathlib (uses the `dir` field, verified manually with a local setup)