### PR TITLE
Cleanup: fix unicode edits, async race, dedup, dead code

### DIFF
--- a/leanclient/base_client.py
+++ b/leanclient/base_client.py
@@ -71,6 +71,8 @@ class BaseLeanLSPClient:
         # Asyncio infrastructure for non-blocking requests
         self._loop = asyncio.new_event_loop()
         self._futures = {}  # {request_id: asyncio.Future}
+        self._futures_lock = threading.Lock()  # guards _futures and request_id
+        self._write_lock = threading.Lock()  # serializes writes to stdin
         self._notification_handlers: dict[str, Callable[[dict], Any]] = {}
 
         # Start event loop in a separate thread
@@ -288,8 +290,11 @@ class BaseLeanLSPClient:
                 continue
 
             # Handle response to a request
-            if msg_id is not None and msg_id in self._futures:
-                future = self._futures.pop(msg_id)
+            future = None
+            if msg_id is not None:
+                with self._futures_lock:
+                    future = self._futures.pop(msg_id, None)
+            if future is not None:
                 # Check if event loop is still running before dispatching
                 if self._loop and not self._loop.is_closed():
                     if "error" in msg:
@@ -315,45 +320,30 @@ class BaseLeanLSPClient:
         # Cancel all pending futures — process is dead, these will never resolve
         if self._loop and not self._loop.is_closed():
             err = EOFError("Language server process exited unexpectedly.")
-            for future in self._futures.values():
+            with self._futures_lock:
+                pending = list(self._futures.values())
+                self._futures.clear()
+            for future in pending:
                 if not future.done():
                     self._loop.call_soon_threadsafe(future.set_exception, err)
-            self._futures.clear()
 
-    def _send_request_rpc(
-        self, method: str, params: dict, is_notification: bool
-    ) -> int | None:
-        """Send a JSON RPC request to the language server.
+    def _write_message(self, message: dict) -> None:
+        """Serialize and write a JSON-RPC message to the server's stdin.
+
+        Writes are serialized with a lock so messages from different threads
+        cannot interleave on the pipe.
 
         Args:
-            method (str): Method name.
-            params (dict): Parameters for the method.
-            is_notification (bool): Whether the request is a notification.
-
-        Returns:
-            int | None: Id of the request if it is not a notification.
+            message (dict): Full JSON-RPC message (including ``id`` for requests).
         """
-        if not is_notification:
-            request_id = self.request_id
-            self.request_id += 1
-
-        request = {
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-            **({"id": request_id} if not is_notification else {}),
-        }
-
-        body = orjson.dumps(request)
+        body = orjson.dumps(message)
         header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
-        self.stdin.write(header + body)
-        self.stdin.flush()
+        with self._write_lock:
+            self.stdin.write(header + body)
+            self.stdin.flush()
 
         if self.enable_history:
-            self.history.append({"type": "client", "content": request})
-
-        if not is_notification:
-            return request_id
+            self.history.append({"type": "client", "content": message})
 
     def _send_notification(self, method: str, params: dict):
         """Send a notification to the language server.
@@ -362,10 +352,14 @@ class BaseLeanLSPClient:
             method (str): Method name.
             params (dict): Parameters for the method.
         """
-        self._send_request_rpc(method, params, is_notification=True)
+        self._write_message({"jsonrpc": "2.0", "method": method, "params": params})
 
     def _send_request_async(self, method: str, params: dict) -> asyncio.Future:
         """Send a request and return an asyncio.Future immediately (non-blocking).
+
+        The future is registered before the request is written, so a fast
+        response read by the stdout thread cannot arrive before the future
+        exists to receive it.
 
         Args:
             method (str): Method name.
@@ -374,9 +368,15 @@ class BaseLeanLSPClient:
         Returns:
             asyncio.Future: Future that will be resolved when the response arrives.
         """
-        req_id = self._send_request_rpc(method, params, is_notification=False)
         future = self._loop.create_future()
-        self._futures[req_id] = future
+        with self._futures_lock:
+            request_id = self.request_id
+            self.request_id += 1
+            self._futures[request_id] = future
+
+        self._write_message(
+            {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+        )
         return future
 
     def _send_request_sync(

--- a/leanclient/client.py
+++ b/leanclient/client.py
@@ -445,30 +445,7 @@ class LeanLSPClient(LSPFileManager, BaseLeanLSPClient):
         Returns:
             list: Document symbols.
         """
-        path = self._normalize_local_path(path)
-
-        with self._opened_files_lock:
-            if path not in self.opened_files:
-                needs_open = True
-            else:
-                needs_open = False
-
-        if needs_open:
-            self.open_file(path)
-
-        # Wait for file to be processed if needed
-        with self._opened_files_lock:
-            state = self.opened_files[path]
-            uri = state.uri
-            version = state.version
-            need_wait = not state.complete
-
-        if need_wait:
-            self._wait_for_diagnostics([uri], inactivity_timeout=5.0)
-            with self._opened_files_lock:
-                version = self.opened_files[path].version
-
-        # Send request
+        uri, version = self._ensure_file_processed(path)
         params = {"textDocument": {"uri": uri, "version": version}}
         response = self._send_request_sync("textDocument/documentSymbol", params)
 
@@ -574,30 +551,7 @@ class LeanLSPClient(LSPFileManager, BaseLeanLSPClient):
         Returns:
             list: Folding ranges.
         """
-        path = self._normalize_local_path(path)
-
-        with self._opened_files_lock:
-            if path not in self.opened_files:
-                needs_open = True
-            else:
-                needs_open = False
-
-        if needs_open:
-            self.open_file(path)
-
-        # Wait for file to be processed if needed
-        with self._opened_files_lock:
-            state = self.opened_files[path]
-            uri = state.uri
-            version = state.version
-            need_wait = not state.complete
-
-        if need_wait:
-            self._wait_for_diagnostics([uri], inactivity_timeout=5.0)
-            with self._opened_files_lock:
-                version = self.opened_files[path].version
-
-        # Send request
+        uri, version = self._ensure_file_processed(path)
         params = {"textDocument": {"uri": uri, "version": version}}
         return self._send_request_sync("textDocument/foldingRange", params)
 

--- a/leanclient/file_manager.py
+++ b/leanclient/file_manager.py
@@ -57,6 +57,14 @@ class DiagnosticsResult:
 # Grace period for Lean 4.22 compatibility (empty diagnostics arrive before real ones)
 DIAGNOSTICS_GRACE_PERIOD = 0.5
 
+# Max time to block on the close condition between re-checks while waiting for
+# diagnostics. Notifications wake the waiter early; this only bounds how quickly
+# time-based readiness (grace period / inactivity) is re-evaluated.
+WAIT_POLL_INTERVAL = 0.05
+
+# Unique sentinel for "no previous result yet" in retry loops.
+_NO_PREVIOUS_RESULT = object()
+
 
 @dataclass(slots=True)
 class FileState:
@@ -411,7 +419,7 @@ class LSPFileManager(BaseLeanLSPClient):
         Returns:
             dict: Final response.
         """
-        prev_results = "Nvr_gnn_gv_y_p"
+        prev_results = _NO_PREVIOUS_RESULT
         retry_count = 0
         while True:
             results = self._send_request(
@@ -429,6 +437,39 @@ class LSPFileManager(BaseLeanLSPClient):
                 prev_results = results
 
         return results
+
+    def _ensure_file_processed(self, path: str) -> tuple[str, int]:
+        """Open ``path`` if needed, wait until processed, return (uri, version).
+
+        Shared by document-wide requests (e.g. document symbols, folding ranges)
+        that need the file fully processed before querying.
+
+        Args:
+            path (str): Relative file path.
+
+        Returns:
+            tuple[str, int]: The file URI and its current version.
+        """
+        path = self._normalize_local_path(path)
+
+        with self._opened_files_lock:
+            needs_open = path not in self.opened_files
+
+        if needs_open:
+            self.open_file(path)
+
+        with self._opened_files_lock:
+            state = self.opened_files[path]
+            uri = state.uri
+            version = state.version
+            need_wait = not state.complete
+
+        if need_wait:
+            self._wait_for_diagnostics([uri], inactivity_timeout=5.0)
+            with self._opened_files_lock:
+                version = self.opened_files[path].version
+
+        return uri, version
 
     def open_files(
         self,
@@ -554,11 +595,6 @@ class LSPFileManager(BaseLeanLSPClient):
 
             uri = state.uri
             version = state.version
-
-        # TODO: Any of these useful?
-        # params = ("textDocument/didSave", {"textDocument": {"uri": uri}, "text": text})
-        # params = ("workspace/applyEdit", {"changes": [{"textDocument": {"uri": uri, "version": 1}, "edits": [c.get_dict() for c in changes]}]})
-        # params = ("workspace/didChangeWatchedFiles", {"changes": [{"uri": uri, "type": 2}]})
 
         params = (
             "textDocument/didChange",
@@ -972,9 +1008,10 @@ class LSPFileManager(BaseLeanLSPClient):
                     )
                     return False
 
-                # Use condition variable wait with timeout instead of busy polling
-                # Wake up on notification or after 5ms, whichever comes first
-                self._close_condition.wait(timeout=0.005)
+                # Wake up on notification or after the poll interval, whichever
+                # comes first (notifications drive progress; the timeout only
+                # bounds time-based readiness re-checks).
+                self._close_condition.wait(timeout=WAIT_POLL_INTERVAL)
 
         # Should not reach here, but return False as safety
         return False
@@ -1078,8 +1115,9 @@ class LSPFileManager(BaseLeanLSPClient):
                     )
                     return False
 
-                # Wait for line range completion
-                self._close_condition.wait(timeout=0.005)
+                # Wait for line range completion (notification-driven; the
+                # timeout only bounds time-based readiness re-checks).
+                self._close_condition.wait(timeout=WAIT_POLL_INTERVAL)
 
         # Should not reach here, but return False as safety
         return False

--- a/leanclient/info_tree.py
+++ b/leanclient/info_tree.py
@@ -109,8 +109,6 @@ def _parse_goals(node: dict) -> dict:
                 elif line.startswith("after"):
                     after_idx = i
             if before_idx is not None and after_idx is not None:
-                before = extra[before_idx:after_idx]
-                before[0] = before[0].replace("before", "")
                 node["goals_before"] = "\n".join(
                     extra[before_idx + 1 : after_idx]
                 ).strip()

--- a/leanclient/utils.py
+++ b/leanclient/utils.py
@@ -102,10 +102,12 @@ def _utf16_pos_to_utf8_pos(text: str, line: int, utf16_character: int) -> int:
 
     lines = text.split("\n")
     if line >= len(lines):
-        return len(text)
+        return len(text.encode("utf-8"))
 
-    # Get byte offset to start of line
-    line_start_byte = sum(len(lines[i]) + 1 for i in range(line))  # +1 for '\n'
+    # Get byte offset to start of line (count UTF-8 bytes of preceding lines)
+    line_start_byte = sum(
+        len(lines[i].encode("utf-8")) + 1 for i in range(line)
+    )  # +1 for '\n'
 
     # Convert UTF-16 character offset to UTF-8 byte offset within the line
     line_content = lines[line]
@@ -194,9 +196,14 @@ def apply_changes_to_text(text: str, changes: list[DocumentContentChange]) -> st
             continue
 
         assert change.start is not None and change.end is not None
+        # Indices are UTF-8 byte offsets, so splice on the encoded bytes to keep
+        # positions correct for lines containing non-ASCII characters.
+        data = text.encode("utf-8")
         start_idx = _index_from_line_character(text, change.start[0], change.start[1])
         end_idx = _index_from_line_character(text, change.end[0], change.end[1])
-        text = text[:start_idx] + change.text + text[end_idx:]
+        text = (data[:start_idx] + change.text.encode("utf-8") + data[end_idx:]).decode(
+            "utf-8"
+        )
 
     return text
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -177,6 +177,28 @@ def test_apply_normalizes_input():
     assert result == "hello\nXworld"
 
 
+@pytest.mark.unit
+def test_apply_ranged_change_after_unicode_on_line():
+    """Edits after a non-ASCII char on the same line must land correctly.
+
+    Positions are UTF-16 offsets; '⊢' is 3 UTF-8 bytes but 1 UTF-16 unit.
+    """
+    original = "theorem foo : ⊢ x = y\nsecond line"
+    changes = [DocumentContentChange("Z", [0, 16], [0, 16])]
+    result = apply_changes_to_text(original, changes)
+    assert result == "theorem foo : ⊢ Zx = y\nsecond line"
+
+
+@pytest.mark.unit
+def test_apply_ranged_change_after_unicode_on_prior_line():
+    """Edits on a line preceded by non-ASCII lines must land correctly."""
+    original = "∀ x\n⊢ y = y\nlast"
+    # Replace "y = y" (chars 2..7 on line 1) with "z"
+    changes = [DocumentContentChange("z", [1, 2], [1, 7])]
+    result = apply_changes_to_text(original, changes)
+    assert result == "∀ x\n⊢ z\nlast"
+
+
 # ============================================================================
 # needs_mathlib_cache_get tests
 # ============================================================================


### PR DESCRIPTION
Functionality-preserving cleanup pass (plus two real bug fixes). Picked items from the review.

## Bug fixes
- **A1 — unicode edit corruption.** `apply_changes_to_text` used a UTF-8 byte offset as a Python `str` index, so ranged edits on lines containing non-ASCII chars (`⊢ ∀ ≤ →`, very common in Lean) spliced at the wrong position and desynced the in-memory copy from the server (`get_file_content`, code-action apply). Now splices on the encoded bytes and counts preceding lines in bytes too. Regression tests added (`test_apply_ranged_change_after_unicode_*`).
- **A2 — async response race.** `_send_request_async` wrote the request *before* registering its future, so a fast/cached reply read by the stdout thread could be dropped (caller then blocks to timeout). The future is now registered before the write; `_futures`/`request_id` are guarded by a lock and stdin writes are serialized.

## Cleanup (no behavior change)
- **B2** — extract the duplicated open+wait block from `get_document_symbols` / `get_folding_ranges` into `_ensure_file_processed`.
- **B3** — remove dead `before` slice in `info_tree._parse_goals`.
- **B4** — replace magic-string retry sentinel `"Nvr_gnn_gv_y_p"` with a unique `object()`.
- **B6** — drop the commented-out `didSave`/`applyEdit`/`didChangeWatchedFiles` experiments in `update_file`.
- **D2** — name the diagnostics-wait poll interval and widen it from 5ms to 50ms (notification-driven; the timeout only bounds time-based re-checks), cutting idle wakeups ~10x.

## Testing
- All 53 unit tests pass (incl. new unicode regression tests).
- Integration tests run against a real `lake serve` (Lean v4.25.0): async/race (A2), file-manager update/open/content (A1), document-symbols/folding (B2), single-file-client, code-actions — all pass.
- `ruff check` + `ruff format --check` clean.