### PR TITLE
Lean 4.30 test fixups + info_trees module-system fix

### DIFF
--- a/leanclient/client.py
+++ b/leanclient/client.py
@@ -1096,9 +1096,21 @@ class LeanLSPClient(LSPFileManager, BaseLeanLSPClient):
         Returns:
             list: List of info trees as raw strings or parsed into structured data if `parse` is True.
         """
-        # Find the lines of all "method" symbols in the document (e.g. "theorem")
+        # Find the lines of all "method" symbols in the document (e.g. "theorem").
+        # Lean's module system nests declarations under `section`/namespace
+        # symbols, so recurse into children. get_document_symbols only maps
+        # top-level kinds to strings; nested symbols keep the raw int (6 = method).
         symbols = self.get_document_symbols(path)
-        lines = [s["range"]["start"]["line"] for s in symbols if s["kind"] == "method"]
+
+        def _method_lines(syms: list) -> list:
+            found = []
+            for s in syms:
+                if s.get("kind") in ("method", 6):
+                    found.append(s["range"]["start"]["line"])
+                found.extend(_method_lines(s.get("children") or []))
+            return found
+
+        lines = _method_lines(symbols)
 
         if not lines:
             return []

--- a/tests/fixtures/project_setup.py
+++ b/tests/fixtures/project_setup.py
@@ -83,6 +83,13 @@ def _create_project(path, name, version, use_mathlib=False, force=False):
     with open(os.path.join(path, "lakefile.toml"), "w") as f:
         f.write(toml)
 
+    # Pin the project toolchain to the requested version (= the mathlib rev).
+    # A stale lean-toolchain from a previous build can mismatch mathlib's
+    # toolchain, which makes `lake exe cache get` refuse to download oleans;
+    # the server then reads incompatible oleans and reports fatal errors.
+    with open(os.path.join(path, "lean-toolchain"), "w") as f:
+        f.write(f"leanprover/lean4:{version}\n")
+
     subprocess.run("lake update --keep-toolchain", shell=True, cwd=path)
     subprocess.run("lake exe cache get", shell=True, cwd=path)
     subprocess.run("lake build", shell=True, cwd=path)

--- a/tests/integration/test_client_errors.py
+++ b/tests/integration/test_client_errors.py
@@ -15,7 +15,7 @@ EXP_DIAGNOSTIC_ERRORS = [
     "unexpected end of input; expected ':'",
 ]
 
-EXP_DIAGNOSTIC_WARNINGS = ["declaration uses 'sorry'", "declaration uses 'sorry'"]
+EXP_DIAGNOSTIC_WARNINGS = ["declaration uses `sorry`", "declaration uses `sorry`"]
 
 
 # ============================================================================

--- a/tests/integration/test_client_requests.py
+++ b/tests/integration/test_client_requests.py
@@ -395,7 +395,11 @@ def test_mathlib_file(lsp_client):
             ]
         )
 
-    references = lsp_client.get_references(path, finset_line, finset_char)
+    # Whole-project reference indexing is slower to settle on newer toolchains;
+    # retry more patiently so the full result set is gathered.
+    references = lsp_client.get_references(
+        path, finset_line, finset_char, max_retries=8, retry_delay=0.2
+    )
     flat = set([flatten(ref) for ref in references])
     # Reference count can vary between mathlib versions
     flat_count = len(flat)

--- a/tests/integration/test_file_manager.py
+++ b/tests/integration/test_file_manager.py
@@ -233,7 +233,8 @@ def test_update_try_tactics(file_manager):
     diag_init = file_manager.get_diagnostics(file_path)
     assert diag_init == [], f"Expected no diagnostics, got {diag_init}"
 
-    line, character = (26, 61)
+    # Position of the `linarith` proving the `?_` side goal in the first theorem.
+    line, character = (30, 61)
     tactics = ["simp", "aesop", "norm_num", "omega", "linarith"]
     l_tactic = len("linarith")
     messages = {}

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -28,6 +28,8 @@ def test_get_env_as_dict(base_client):
         "LAKE_CACHE_DIR",
         "LAKE_CACHE_KEY",
         "LAKE_CACHE_REVISION_ENDPOINT",
+        "LAKE_CACHE_SERVICE",
+        "LAKE_CONFIG",
         "LAKE_HOME",
         "LAKE_NO_CACHE",
         "LAKE_PKG_URL_MAP",


### PR DESCRIPTION
Follow-up to #41 (Lean 4.30 bump): makes the full suite green on 4.30. Two fixes plus test-expectation updates.

## Fixes
- **Fixture (root cause of the mathlib `fatalError` cascade).** `tests/fixtures/project_setup.py` now pins the test project's `lean-toolchain` to the target version so it matches the mathlib rev. Previously a stale `lean-toolchain` made `lake exe cache get` refuse to download oleans → the 4.30 server read incompatible oleans → `LeanFileProgressKind.fatalError` on every mathlib file (manifesting as `KeyError: 'range'`, `diag != []`, "file worker terminated", timeouts).
- **Library: `get_info_trees` recurses into nested symbols.** Lean's module system (`public section` / namespace) nests theorem symbols, so the old top-level-only scan found 0 methods and returned `[]` for all 4.30 mathlib files. Now recurses (matches both mapped `"method"` and raw int `6`). Behaviour is unchanged for flat/top-level files (verified: local test file still yields the same method lines).

## Test-expectation updates for 4.30
- `declaration uses \`sorry\`` — backticks instead of single quotes.
- `test_get_env_as_dict` — `lake env` adds `LAKE_CACHE_SERVICE` and `LAKE_CONFIG`.
- `test_update_try_tactics` — the `linarith` position moved line 26→30 (file gained a `public section`); same char/expected diagnostics, verified empirically.
- `test_mathlib_file` — gather references with more patient retries (whole-project indexing settles slower on 4.30; full set is 6851 refs, was timing out at 4).

## Validation
Clean rebuild of `.test_env` via the **fixed** fixture (confirmed toolchain synced, `cache get` fetched the proper 8459 oleans) + full suite: **205 passed, 3 skipped, 6 xpassed**, with the 14 original 4.30 failures all resolved.

## Note (not changed here)
`tests/integration/test_code_actions.py` and its data file `CodeActionDemo.lean` are untracked local-only files (not in git, excluded from CI by `-m "not integration"`). The test asserts `CodeActionDemo.lean` exists but nothing creates it, so it breaks whenever `.test_env` is rebuilt (e.g. on a version bump). Worth either committing both (and copying the data file in the fixture) or having the test generate the file.