### PR TITLE
Add ty type checking; make the library pass it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
       - run: uv sync --extra dev
       - run: uv run ruff check .
       - run: uv run ruff format --check .
+      - run: uv run ty check
   
   test-full:
     runs-on: ${{ matrix.os }}

--- a/leanclient/base_client.py
+++ b/leanclient/base_client.py
@@ -65,6 +65,8 @@ class BaseLeanLSPClient:
             stdin=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
         )
+        assert self.process.stdin is not None
+        assert self.process.stdout is not None
         self.stdin = self.process.stdin
         self.stdout = self.process.stdout
 
@@ -381,7 +383,7 @@ class BaseLeanLSPClient:
 
     def _send_request_sync(
         self, method: str, params: dict, timeout: float | None = 120.0
-    ) -> dict:
+    ) -> Any:
         """Send a request and block until response arrives.
 
         Args:

--- a/leanclient/file_manager.py
+++ b/leanclient/file_manager.py
@@ -346,7 +346,7 @@ class LSPFileManager(BaseLeanLSPClient):
 
     def _send_request(
         self, path: str, method: str, params: dict, timeout: float = 30.0
-    ) -> dict:
+    ) -> Any:
         """Send request about a document and return a response or and error.
 
         Args:
@@ -406,7 +406,7 @@ class LSPFileManager(BaseLeanLSPClient):
         params: dict,
         max_retries: int = 1,
         retry_delay: float = 0.0,
-    ) -> dict:
+    ) -> Any:
         """Send requests until no new results are found after a number of retries.
 
         Args:
@@ -1019,8 +1019,8 @@ class LSPFileManager(BaseLeanLSPClient):
     def _wait_for_line_range(
         self,
         uris: list[str],
-        start_line: int,
-        end_line: int,
+        start_line: int | None,
+        end_line: int | None,
         inactivity_timeout: float = 3.0,
     ) -> bool:
         """Wait for specific line range to complete based on parallel processing ranges.

--- a/leanclient/info_tree.py
+++ b/leanclient/info_tree.py
@@ -48,7 +48,7 @@ def parse_info_tree(info_tree_str: str) -> dict:
         dict: A nested dictionary representing the parsed info tree.
     """
     lines = info_tree_str.strip().splitlines()
-    stack = [{"children": []}]
+    stack: list[dict] = [{"children": []}]
 
     for line in lines:
         if match := node_pattern.match(line):

--- a/leanclient/pool.py
+++ b/leanclient/pool.py
@@ -8,6 +8,9 @@ import tqdm
 
 from leanclient import LeanLSPClient, SingleFileClient
 
+# Per-worker client, created in _init_worker (one LeanLSPClient per pool process).
+client: LeanLSPClient
+
 
 def _init_worker(project_path: str, kwargs: dict):
     global client
@@ -88,7 +91,7 @@ class LeanClientPool:
         self._init_args = kwargs
 
         self.num_workers = (
-            int(os.cpu_count() * 0.7) if num_workers is None else num_workers
+            int((os.cpu_count() or 1) * 0.7) if num_workers is None else num_workers
         )
 
         self.mp_context = get_context("spawn")

--- a/leanclient/single_file_client.py
+++ b/leanclient/single_file_client.py
@@ -55,7 +55,7 @@ class SingleFileClient:
         """
         return self.client.close_files([self.file_path], blocking)
 
-    def update_file(self, changes: list[DocumentContentChange]) -> list:
+    def update_file(self, changes: list[DocumentContentChange]) -> None:
         """See :meth:`leanclient.client.LeanLSPClient.update_file`"""
         return self.client.update_file(self.file_path, changes)
 
@@ -89,7 +89,7 @@ class SingleFileClient:
         """See :meth:`leanclient.client.LeanLSPClient.get_completion_item_resolve`"""
         return self.client.get_completion_item_resolve(item)
 
-    def get_hover(self, line: int, character: int) -> dict:
+    def get_hover(self, line: int, character: int) -> dict | None:
         """See :meth:`leanclient.client.LeanLSPClient.get_hover`"""
         return self.client.get_hover(self.file_path, line, character)
 
@@ -162,11 +162,11 @@ class SingleFileClient:
         """See :meth:`leanclient.client.LeanLSPClient.get_call_hierarchy_outgoing`"""
         return self.client.get_call_hierarchy_outgoing(item)
 
-    def get_goal(self, line: int, character: int) -> dict:
+    def get_goal(self, line: int, character: int) -> dict | None:
         """See :meth:`leanclient.client.LeanLSPClient.get_goal`"""
         return self.client.get_goal(self.file_path, line, character)
 
-    def get_term_goal(self, line: int, character: int) -> dict:
+    def get_term_goal(self, line: int, character: int) -> dict | None:
         """See :meth:`leanclient.client.LeanLSPClient.get_term_goal`"""
         return self.client.get_term_goal(self.file_path, line, character)
 

--- a/leanclient/utils.py
+++ b/leanclient/utils.py
@@ -1,9 +1,10 @@
 # Varia to be sorted later...
 import logging
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 
 import orjson
 
@@ -143,8 +144,8 @@ class DocumentContentChange:
     """Represents a change in a document."""
 
     text: str
-    start: Tuple[int, int] | None = None
-    end: Tuple[int, int] | None = None
+    start: Sequence[int] | None = None
+    end: Sequence[int] | None = None
 
     def __post_init__(self) -> None:
         normalized_text = normalize_newlines(self.text)
@@ -209,7 +210,7 @@ def apply_changes_to_text(text: str, changes: list[DocumentContentChange]) -> st
 
 
 def get_diagnostics_in_range(
-    diagnostics: list,
+    diagnostics: Iterable[dict],
     start_line: int,
     end_line: int,
 ) -> list:
@@ -284,7 +285,7 @@ def experimental(func):
 
     # Change __doc__ to include a sphinx warning
     warning = "\n        .. admonition:: Experimental\n\n            This method is experimental. Use with caution.\n            Warnings are logged via the 'leanclient' logger.\n"
-    doc_lines = wrapper.__doc__.split("\n")
+    doc_lines = (wrapper.__doc__ or "").split("\n")
     doc_lines.insert(1, warning)
     wrapper.__doc__ = "\n".join(doc_lines)
     return wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "sphinx>=8.1.3",
     "sphinx-rtd-theme>=3.0.2",
     "ipykernel>=6.29.5",
+    "ty>=0.0.46",
 ]
 test = [
     "pytest>=8.0",
@@ -44,6 +45,13 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["leanclient"]
+
+[tool.ty.environment]
+# Type-check against the minimum supported Python version.
+python-version = "3.10"
+
+[tool.ty.src]
+include = ["leanclient"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "leanclient"
-version = "0.9.3"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },
@@ -615,6 +615,7 @@ dev = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-rtd-theme" },
+    { name = "ty" },
 ]
 test = [
     { name = "psutil" },
@@ -651,6 +652,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=8.1.3" },
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = ">=3.0.2" },
     { name = "tqdm", specifier = ">=4.67.1" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.46" },
 ]
 provides-extras = ["dev", "test"]
 
@@ -1480,6 +1482,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.46"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/7d/d95b5a9dea83472006be3ce5e480028c44b34138d84d0172e910f287fb69/ty-0.0.46.tar.gz", hash = "sha256:c6c2d7105b5633b49950b4c3a90d1ed2613eb9d794ad582bbbf6c4ffcb93accf", size = 5832380, upload-time = "2026-06-09T03:28:05.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/24/f9f7533c391610521f4164e6b8e37ef72d0c1ee8651bc0d9ce9e658b953b/ty-0.0.46-py3-none-linux_armv6l.whl", hash = "sha256:5e716337994699cbc1a1a7b7a3e6622306f2574c710330f9d9691c2c3d8391b0", size = 11756264, upload-time = "2026-06-09T03:28:20.112Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/ff3d13655b9b5cc8176f4c3446bf7ec2df43c8ad9e5272d4adc5d952fa45/ty-0.0.46-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51d618dec5403635690d0e3e298cd0ad3d84ebc6a576652939ef30ce96fce4b2", size = 11492723, upload-time = "2026-06-09T03:28:13.23Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4a/e7e3209e353c5835c7756339bbcdfda10852407b80fbb9ed46c17241873a/ty-0.0.46-py3-none-macosx_11_0_arm64.whl", hash = "sha256:acbafd6a2351b07a6cf4c945b0b1d47f6d2826faac2526a351dfa74d3a3cc664", size = 10892822, upload-time = "2026-06-09T03:27:51.179Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/20/4390c90434a9ddefcecb65e8df00e4c2700e9739dc0baf58bed36d25f713/ty-0.0.46-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de5df602ffd760612ae36602bbad69b0123ff6cffd92e62aa92b7709317d69e3", size = 11408745, upload-time = "2026-06-09T03:27:58.049Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0c/f13a1bf9c6798530c773667095a6cf8f73ec9721db359423e7249bff7fbc/ty-0.0.46-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7abf5a10b30d8641faad90f6a19989daec941bb90261159e05cfeb04d2012046", size = 11544432, upload-time = "2026-06-09T03:27:53.519Z" },
+    { url = "https://files.pythonhosted.org/packages/56/69/eb3710c13dff846a0362df04fadd8a39b64ccc244c0d02ce5285ede8eae5/ty-0.0.46-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8770404139c6ccee2ce2fc226478cfa4100915133c876c257e52197b8b92051d", size = 12031228, upload-time = "2026-06-09T03:28:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/68/5f5db9c84c1d44acdc67281089b372d9d818ee68123a60c59c66187095e2/ty-0.0.46-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f960d5a6e4860076924d2b86891d9872c4a3daa4663fb416e640b22cf3dbf68e", size = 12596073, upload-time = "2026-06-09T03:28:25.204Z" },
+    { url = "https://files.pythonhosted.org/packages/14/be/cfd0bb272e6a1491f6de30c60da1f39c2b3c3524ec64a5c92b71365c9185/ty-0.0.46-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d9000a4a3ed08fc37e8a2ff0b801cde06e1c2af3bc053677744bb5a1b751030", size = 12284885, upload-time = "2026-06-09T03:28:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/2cd541f6320f5d6f70a45725c4e1016efedd5545348bb23b47ffb3e4c724/ty-0.0.46-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1160e6dc86536109ab755f7142f36f4dda5333c8330cf230d61819494d27125", size = 12079480, upload-time = "2026-06-09T03:27:55.847Z" },
+    { url = "https://files.pythonhosted.org/packages/de/91/8e0075bc6568fb477e7ef4d805c67fa6902b692cb4419e0bf5ce3c04c5bc/ty-0.0.46-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b619c0efe007731f8221fa787701bfa4402da7a83eb26c61ae25e77b6ace6384", size = 12316547, upload-time = "2026-06-09T03:28:08.28Z" },
+    { url = "https://files.pythonhosted.org/packages/00/28/b96cbfeda019a4044c6a8cd06ff84d08b631d4ba7d9a1e6dc0311df3563a/ty-0.0.46-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ad98fccb6a8a94c4121b993761a0deee602f5826c4162e0a91f4f8118ddadd42", size = 11392846, upload-time = "2026-06-09T03:28:00.418Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d0/4d77f699a95ac7a13b94ca1a58682667cfe974f91557d9e2a9fc0b808a7f/ty-0.0.46-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:74536b13c3cc3f5944408669c202d4c57c3d19ff154732df8e6145718aef9191", size = 11559017, upload-time = "2026-06-09T03:28:17.619Z" },
+    { url = "https://files.pythonhosted.org/packages/88/62/1d6f6b51c2b132da8011c6a41ead0c1fd2a0b17ea72304bcf6ce084d581a/ty-0.0.46-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5e50b1e96ced41b609e24ed27d9e4f508584ed7f4d0bb717ca8c8d75d2fd1b7c", size = 11666509, upload-time = "2026-06-09T03:28:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9a/6643894bc12cb30c281f4c8bf37f6d30c1fbd9484ef39a12b0ea6dae3c1c/ty-0.0.46-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0a7d9f58d26d938e5d2f607481b7a412d8c00d675a1ec72004fa9d6b3b9def99", size = 12180448, upload-time = "2026-06-09T03:28:32.329Z" },
+    { url = "https://files.pythonhosted.org/packages/86/68/0f3b7bb03a7da676ef51b1c0af0bde1e500d69d5f0c807ed63b6f30b66dd/ty-0.0.46-py3-none-win32.whl", hash = "sha256:26db0ce89c573e60132d14e9688c9329a1633b1a8c26fe457025c7c406f7d5e6", size = 10960002, upload-time = "2026-06-09T03:28:02.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f4/91ff618b2dee39d0633d23e1adac0174aa1de80df17e270acac534034dbc/ty-0.0.46-py3-none-win_amd64.whl", hash = "sha256:90e8e6d446b9cb7cb4bede9fca7b3c99fd1e2355605ecf431c131a51db2a5e93", size = 12097413, upload-time = "2026-06-09T03:28:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2e/300174fca375a27a7c28dd80e990d857d7b3e3b25980c65063f980aa2f17/ty-0.0.46-py3-none-win_arm64.whl", hash = "sha256:ebd320d82605079b901a095dc4711037a0c488b4ace79a602fef4df0d3f4cf74", size = 11439595, upload-time = "2026-06-09T03:28:15.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Wires Astral's `ty` type checker into the project (fits the existing ruff/uv stack) and makes the whole `leanclient` package pass it — **37 diagnostics → 0**.

Per our constraint, this is **API-preserving**: no method names, signatures, parameter names/defaults, or runtime behaviour change. Every edit is either an annotation correction (making the declared type match what the code already returns at runtime) or a runtime-safe guard.

## Type-checking setup
- `leanclient/py.typed` so the now-correct hints are actually exported to consumers (e.g. lean-lsp-mcp) — they currently see none.
- `ty` added as a dev dep; `[tool.ty]` config checks `leanclient` against the **3.10** floor; CI lint job runs `uv run ty check`.

## Fixes (all API-preserving)
- **base_client**: `assert stdin/stdout is not None` after `Popen(PIPE)` so the IO attrs narrow from `IO | None`; `_send_request_sync -> Any`.
- **file_manager**: `_send_request` / `_send_request_retry -> Any` (they return arbitrary server JSON — widening, never constrains callers); `_wait_for_line_range` accepts `int | None`.
- **utils**: `DocumentContentChange.start/end` widened to `Sequence[int] | None` (the README/API already passes lists); `get_diagnostics_in_range` takes `Iterable[dict]` (it's handed the list-like `DiagnosticsResult`); guard `__doc__` in the `experimental` decorator.
- **single_file_client**: corrected hints to match runtime — `update_file -> None`, `get_hover/get_goal/get_term_goal -> dict | None` (these *always* could return `None`; the old `-> dict` was simply wrong).
- **info_tree**: annotate the parse stack; **pool**: declare the per-worker `client` global and guard `os.cpu_count()` being `None`.

## Validation
- `ty check` (via config, py3.10): **All checks passed!**
- 53 unit tests pass; async + single-file-client integration tests pass (exercise client init / the new asserts); ruff check + format clean.
- Confirmed `py.typed` ships in the built wheel.

Notably `client.py` needed **no** edits — its ~18 errors all resolved from the shared helper/`utils` type corrections.