### PR TITLE
Fix flaky test_server_queues_requests timing assertion

### DIFF
--- a/tests/integration/test_server_timing.py
+++ b/tests/integration/test_server_timing.py
@@ -114,17 +114,23 @@ def test_server_queues_requests_and_handles_concurrent_calls(test_project_dir):
                 },
             )
 
-        # Collect responses
+        # Collect responses. Budget on wall-clock time rather than a fixed
+        # message count: the server streams many fileProgress/diagnostic
+        # notifications while elaborating, and a count-based loop can be
+        # exhausted by those before the slowest hover resolves (flaky under
+        # CI load, especially on slower runners).
         responses = {}
         diag_time = None
+        req_ids = [r[0] for r in requests]
+        deadline = time.time() + 120
 
-        for _ in range(300):  # 30s max
-            msg = read_rpc_message(process.stdout, timeout=0.1)
+        while time.time() < deadline:
+            msg = read_rpc_message(process.stdout, timeout=0.5)
             if not msg:
                 continue
 
             msg_id = msg.get("id")
-            if msg_id in [r[0] for r in requests] and msg_id not in responses:
+            if msg_id in req_ids and msg_id not in responses:
                 responses[msg_id] = time.time() - time_start
 
             if msg.get("method") == "textDocument/publishDiagnostics" and not diag_time:


### PR DESCRIPTION
## What's up (CI analysis)
CI has been red since the 4.30 bump (#41, #42, and #43's run). The cause is a **single flaky test** — everything else (lint, `ty`, the full py3.13 job, all other tests) passes:

```
test-full (3.10): FAILED tests/integration/test_server_timing.py::test_server_queues_requests_and_handles_concurrent_calls
  AssertionError: Only got 2/3 responses (assert 2 == 3)
test-full (3.13): success
lint: success
```

It fails on the slower py3.10 runner and passes on 3.13 — classic timing flake (there's even a prior `fix flaky ... server_queues_requests` commit). It runs in CI because it lacks the `integration` marker that deselects the other raw-server tests.

## Root cause
The test opens a large mathlib file, fires 3 concurrent hovers (lines 10/70/150), and collects responses in a **fixed `for _ in range(300)` loop**. While elaborating, the server streams many `$/lean/fileProgress`/`publishDiagnostics` notifications; each consumes a loop iteration, so the budget can be exhausted before the slowest hover (line 150) resolves.

## Fix
Budget the collection loop on **wall-clock time (120s)** instead of a message count, so streaming notifications can't starve the hovers. No behavior/API change; test-only.

## Validation
Ran the test 3× locally — green each time (~3s). Lint clean.