### PR TITLE
Surface malformed LSP frames

### DIFF
--- a/leanclient/__init__.py
+++ b/leanclient/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from .base_client import LSPProtocolError
 from .utils import DocumentContentChange, SemanticTokenProcessor
 from .single_file_client import SingleFileClient
 from .client import LeanLSPClient
@@ -13,6 +14,7 @@ __all__ = [
     "SingleFileClient",
     "LeanLSPClient",
     "LeanClientPool",
+    "LSPProtocolError",
 ]
 
 # Configure default logging (users can override)

--- a/leanclient/base_client.py
+++ b/leanclient/base_client.py
@@ -27,6 +27,10 @@ ENABLE_LEANCLIENT_HISTORY = (
 )
 
 
+class LSPProtocolError(RuntimeError):
+    """Raised when the language server writes an invalid LSP frame."""
+
+
 class BaseLeanLSPClient:
     """BaseLeanLSPClient runs a language server in a subprocess.
 
@@ -76,6 +80,7 @@ class BaseLeanLSPClient:
         self._futures_lock = threading.Lock()  # guards _futures and request_id
         self._write_lock = threading.Lock()  # serializes writes to stdin
         self._notification_handlers: dict[str, Callable[[dict], Any]] = {}
+        self._reader_error: Exception | None = None
 
         # Start event loop in a separate thread
         self._loop_thread = threading.Thread(
@@ -255,6 +260,88 @@ class BaseLeanLSPClient:
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
+    @staticmethod
+    def _set_future_exception_if_pending(
+        future: asyncio.Future, error: Exception
+    ) -> None:
+        """Fail a future unless another response already completed it."""
+        if not future.done():
+            future.set_exception(error)
+
+    def _fail_pending_futures(self, error: Exception) -> None:
+        """Remember a terminal reader failure and fail every pending request."""
+        with self._futures_lock:
+            if self._reader_error is None:
+                self._reader_error = error
+            pending = list(self._futures.values())
+            self._futures.clear()
+
+        if self._loop and not self._loop.is_closed():
+            for future in pending:
+                self._loop.call_soon_threadsafe(
+                    self._set_future_exception_if_pending, future, error
+                )
+
+    def _read_stdout_message(self) -> dict[str, Any]:
+        """Read and validate one Content-Length framed LSP message."""
+        headers: dict[str, str] = {}
+        raw_headers: list[str] = []
+
+        while True:
+            header_line = self.stdout.readline()
+            if not header_line:
+                raise EOFError("Language server process exited unexpectedly.")
+
+            header = header_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if not header:
+                break
+
+            raw_headers.append(header)
+            name, separator, value = header.partition(":")
+            normalized_name = name.strip().lower()
+            if not separator or not normalized_name:
+                raise LSPProtocolError(f"Malformed LSP header line: {header[:200]!r}")
+            if normalized_name in headers:
+                raise LSPProtocolError(
+                    f"Duplicate LSP header {name.strip()!r}: {header[:200]!r}"
+                )
+            headers[normalized_name] = value.strip()
+
+        raw_content_length = headers.get("content-length")
+        if raw_content_length is None:
+            rendered_headers = ", ".join(repr(header[:200]) for header in raw_headers)
+            raise LSPProtocolError(
+                f"Missing Content-Length LSP header; received [{rendered_headers}]"
+            )
+
+        try:
+            content_length = int(raw_content_length)
+        except ValueError as exc:
+            raise LSPProtocolError(
+                f"Invalid Content-Length LSP header: {raw_content_length!r}"
+            ) from exc
+        if content_length < 0:
+            raise LSPProtocolError(
+                f"Invalid Content-Length LSP header: {raw_content_length!r}"
+            )
+
+        body = self.stdout.read(content_length)
+        if len(body) != content_length:
+            raise LSPProtocolError(
+                "Language server closed before the complete LSP message body "
+                f"arrived: expected {content_length} bytes, got {len(body)}"
+            )
+
+        try:
+            message = orjson.loads(body)
+        except orjson.JSONDecodeError as exc:
+            raise LSPProtocolError("Language server wrote invalid LSP JSON.") from exc
+        if not isinstance(message, dict):
+            raise LSPProtocolError(
+                f"Language server wrote a non-object LSP message: {type(message).__name__}"
+            )
+        return message
+
     def _read_stdout_loop(self, stop_event: threading.Event):
         """Read the stdout of the language server in a separate thread.
 
@@ -263,22 +350,26 @@ class BaseLeanLSPClient:
         """
         while not stop_event.is_set():
             if self.stdout.closed:
+                self._fail_pending_futures(
+                    EOFError("Language server process exited unexpectedly.")
+                )
                 break
 
             try:
-                header = self.stdout.readline()
-            except (EOFError, ValueError):
+                msg = self._read_stdout_message()
+            except EOFError as exc:
+                if not stop_event.is_set():
+                    self._fail_pending_futures(exc)
                 break
-
-            if not header:
+            except Exception as exc:
+                error = (
+                    exc
+                    if isinstance(exc, LSPProtocolError)
+                    else LSPProtocolError(f"Failed to read LSP message: {exc}")
+                )
+                logger.exception("Language server emitted an invalid LSP frame")
+                self._fail_pending_futures(error)
                 break
-
-            # Parse message
-            # Use errors='replace' to handle invalid UTF-8 bytes on Windows
-            header = header.decode("utf-8", errors="replace")
-            content_length = int(header.split(":")[1])
-            next(self.stdout)
-            msg = orjson.loads(self.stdout.read(content_length))
 
             # Dispatch to futures and notification handlers
             msg_id = msg.get("id")
@@ -318,16 +409,6 @@ class BaseLeanLSPClient:
                         handler(msg)
                     except Exception as e:
                         logger.warning(f"Notification handler for {method} failed: {e}")
-
-        # Cancel all pending futures — process is dead, these will never resolve
-        if self._loop and not self._loop.is_closed():
-            err = EOFError("Language server process exited unexpectedly.")
-            with self._futures_lock:
-                pending = list(self._futures.values())
-                self._futures.clear()
-            for future in pending:
-                if not future.done():
-                    self._loop.call_soon_threadsafe(future.set_exception, err)
 
     def _write_message(self, message: dict) -> None:
         """Serialize and write a JSON-RPC message to the server's stdin.
@@ -371,10 +452,20 @@ class BaseLeanLSPClient:
             asyncio.Future: Future that will be resolved when the response arrives.
         """
         future = self._loop.create_future()
+        reader_error = None
         with self._futures_lock:
-            request_id = self.request_id
-            self.request_id += 1
-            self._futures[request_id] = future
+            if self._reader_error is not None:
+                reader_error = self._reader_error
+            else:
+                request_id = self.request_id
+                self.request_id += 1
+                self._futures[request_id] = future
+
+        if reader_error is not None:
+            self._loop.call_soon_threadsafe(
+                self._set_future_exception_if_pending, future, reader_error
+            )
+            return future
 
         self._write_message(
             {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}

--- a/leanclient/base_client.py
+++ b/leanclient/base_client.py
@@ -314,16 +314,11 @@ class BaseLeanLSPClient:
                 f"Missing Content-Length LSP header; received [{rendered_headers}]"
             )
 
-        try:
-            content_length = int(raw_content_length)
-        except ValueError as exc:
-            raise LSPProtocolError(
-                f"Invalid Content-Length LSP header: {raw_content_length!r}"
-            ) from exc
-        if content_length < 0:
+        if not raw_content_length.isascii() or not raw_content_length.isdigit():
             raise LSPProtocolError(
                 f"Invalid Content-Length LSP header: {raw_content_length!r}"
             )
+        content_length = int(raw_content_length)
 
         body = self.stdout.read(content_length)
         if len(body) != content_length:

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -35,6 +35,15 @@ def make_reader_client(stdout: bytes) -> BaseLeanLSPClient:
     return client
 
 
+def make_lsp_frame(body: bytes, *headers: bytes) -> bytes:
+    """Frame a raw body with Content-Length and optional LSP headers."""
+    return (
+        b"\r\n".join((*headers, f"Content-Length: {len(body)}".encode()))
+        + b"\r\n\r\n"
+        + body
+    )
+
+
 @pytest.mark.unit
 @pytest.mark.slow
 def test_initial_build(test_project_dir):
@@ -90,12 +99,49 @@ def test_read_stdout_message_accepts_additional_lsp_headers():
     message = {"jsonrpc": "2.0", "id": 1, "result": {}}
     body = orjson.dumps(message)
     client = make_reader_client(
-        b"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
-        + f"Content-Length: {len(body)}\r\n\r\n".encode()
-        + body
+        make_lsp_frame(body, b"Content-Type: application/vscode-jsonrpc; charset=utf-8")
     )
 
     assert client._read_stdout_message() == message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("stdout", "error"),
+    [
+        (b"Malformed\r\n\r\n", "Malformed LSP header line"),
+        (b"X-Incompatible: nope\r\n\r\n{}", "Missing Content-Length"),
+        (
+            b"Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}",
+            "Duplicate LSP header",
+        ),
+        (b"Content-Length: nope\r\n\r\n", "Invalid Content-Length"),
+        (b"Content-Length: -1\r\n\r\n", "Invalid Content-Length"),
+        (b"Content-Length: +2\r\n\r\n{}", "Invalid Content-Length"),
+    ],
+)
+def test_read_stdout_message_rejects_invalid_headers(stdout, error):
+    """Invalid framing headers fail with a specific protocol error."""
+    client = make_reader_client(stdout)
+
+    with pytest.raises(LSPProtocolError, match=error):
+        client._read_stdout_message()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("body", "error"),
+    [
+        (b"{", "invalid LSP JSON"),
+        (b"[]", "non-object LSP message: list"),
+    ],
+)
+def test_read_stdout_message_rejects_invalid_json_messages(body, error):
+    """LSP payloads must be valid JSON objects."""
+    client = make_reader_client(make_lsp_frame(body))
+
+    with pytest.raises(LSPProtocolError, match=error):
+        client._read_stdout_message()
 
 
 @pytest.mark.unit
@@ -110,6 +156,24 @@ def test_malformed_lsp_header_fails_pending_and_future_requests():
     error = pending.exception()
     assert isinstance(error, LSPProtocolError)
     assert "Missing Content-Length" in str(error)
+    assert client._reader_error is error
+    assert client._futures == {}
+
+    next_request = client._send_request_async("textDocument/hover", {})
+    assert next_request.exception() is error
+
+
+@pytest.mark.unit
+def test_reader_eof_fails_pending_and_future_requests():
+    """EOF fails current requests and is remembered for subsequent ones."""
+    client = make_reader_client(b"")
+    pending = Future()
+    client._futures[7] = pending
+
+    client._read_stdout_loop(threading.Event())
+
+    error = pending.exception()
+    assert isinstance(error, EOFError)
     assert client._reader_error is error
     assert client._futures == {}
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -1,8 +1,38 @@
 """Unit tests for BaseLeanLSPClient."""
 
+import io
+import threading
+from concurrent.futures import Future
+
+import orjson
 import pytest
 
-from leanclient.base_client import BaseLeanLSPClient
+from leanclient.base_client import BaseLeanLSPClient, LSPProtocolError
+
+
+class InlineLoop:
+    """Minimal event-loop surface for reader-thread unit tests."""
+
+    def create_future(self):
+        return Future()
+
+    def is_closed(self):
+        return False
+
+    def call_soon_threadsafe(self, callback, *args):
+        callback(*args)
+
+
+def make_reader_client(stdout: bytes) -> BaseLeanLSPClient:
+    """Create a client shell without launching a real Lean server."""
+    client = object.__new__(BaseLeanLSPClient)
+    client.stdout = io.BytesIO(stdout)
+    client._loop = InlineLoop()
+    client._futures = {}
+    client._futures_lock = threading.Lock()
+    client._reader_error = None
+    client.request_id = 0
+    return client
 
 
 @pytest.mark.unit
@@ -52,3 +82,45 @@ def test_get_env_as_string(base_client):
     env = base_client.get_env(return_dict=False)
     assert isinstance(env, str)
     assert "LEAN=" in env or "ELAN=" in env
+
+
+@pytest.mark.unit
+def test_read_stdout_message_accepts_additional_lsp_headers():
+    """The parser accepts valid LSP frames with more than Content-Length."""
+    message = {"jsonrpc": "2.0", "id": 1, "result": {}}
+    body = orjson.dumps(message)
+    client = make_reader_client(
+        b"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
+        + f"Content-Length: {len(body)}\r\n\r\n".encode()
+        + body
+    )
+
+    assert client._read_stdout_message() == message
+
+
+@pytest.mark.unit
+def test_malformed_lsp_header_fails_pending_and_future_requests():
+    """A bad header becomes a request error instead of killing the reader silently."""
+    client = make_reader_client(b"X-Incompatible: nope\r\n\r\n{}")
+    pending = Future()
+    client._futures[7] = pending
+
+    client._read_stdout_loop(threading.Event())
+
+    error = pending.exception()
+    assert isinstance(error, LSPProtocolError)
+    assert "Missing Content-Length" in str(error)
+    assert client._reader_error is error
+    assert client._futures == {}
+
+    next_request = client._send_request_async("textDocument/hover", {})
+    assert next_request.exception() is error
+
+
+@pytest.mark.unit
+def test_truncated_lsp_body_fails_with_byte_counts():
+    """A partial body reports the framing failure with useful counts."""
+    client = make_reader_client(b"Content-Length: 5\r\n\r\n{}")
+
+    with pytest.raises(LSPProtocolError, match="expected 5 bytes, got 2"):
+        client._read_stdout_message()


### PR DESCRIPTION
## What changed

- Parse complete LSP header blocks instead of assuming the first line is always a valid Content-Length header.
- Raise a dedicated `LSPProtocolError` for malformed framing, truncated bodies, invalid JSON, and non-object JSON-RPC messages.
- Remember terminal reader failures, fail all pending futures, and make later requests fail immediately instead of waiting for unrelated timeouts.
- Export `LSPProtocolError` from the top-level `leanclient` package.
- Cover malformed, missing, duplicate, signed, and non-numeric lengths; extra headers; invalid payloads; truncation; EOF; and requests made after reader failure.

## Root cause

The stdout reader directly split the first header line and converted it to an integer without catching parser failures. If `lake serve` emitted an additional header or malformed frame, the daemon reader thread could exit while pending requests remained unresolved. Callers then saw a generic timeout instead of the protocol failure.

## User impact

Clients such as lean-lsp-mcp now receive an actionable `LSPProtocolError` containing the framing detail. Valid frames with additional LSP headers continue to work.

## Validation

- `pytest tests/aio tests/unit -q`: 99 passed
- `pytest tests/integration -q`: 154 passed, 1 skipped, 6 xpassed
- `ruff check` and `ruff format --check`: passed
- `ty check leanclient`: passed
